### PR TITLE
Mix up devs order so they don't show up in the order they've been added

### DIFF
--- a/src/pages/devs/index.tsx
+++ b/src/pages/devs/index.tsx
@@ -25,6 +25,7 @@ const formSchema = z.object({
 const searchFields: (keyof Profile)[] = ["name", "title"];
 
 export default function DevsPage() {
+  profiles.sort(() => Math.random() - 0.5);
   const [filteredProfiles, setFilteredProfiles] = React.useState(profiles);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
Devs are listed in the same order they are in the json array which is likely the order they've added themselves and creating an incentive for new devs to put themselves at the top. Mixing it up on every reload is cheap and seems a bit more fair.